### PR TITLE
Annotation rotation and placement fix

### DIFF
--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3854,7 +3854,7 @@
         hasWriteLock = YES;
 
         PTPDFDoc *doc = [self.pdfViewCtrl GetDoc];
-
+        
         PTPage* page = [doc GetPage:self.pageNumber];
         PTPDFRect* stampRect = [[PTPDFRect alloc] initWithX1:0 y1:0 x2:self.image.size.width y2:self.image.size.height];
         double maxWidth = 25.0;

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3726,7 +3726,7 @@
         PTImage* stampImage = [PTImage CreateWithDataSimple:[doc GetSDFDoc] buf:data buf_size:data.length encoder_hints:encoderHints];
 
         // Rotate stamp based on the pdfViewCtrl's rotation
-        PTRotate stampRotation = (4 - ctrlRotation) % 4; // 0 = 0, 90 = 1; 180 = 2, and 270 = 3
+        PTRotate stampRotation = 0; // 0 = 0, 90 = 1; 180 = 2, and 270 = 3
         [stamper SetRotation:stampRotation * 90.0];
         [stamper StampImage:doc src_img:stampImage dest_pages:pageSet];
 

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3691,8 +3691,8 @@
         PTMatrix2D *mtx = [page GetDefaultMatrix:NO box_type:e_ptcrop angle:0];
         self.touchPtPage = [mtx Mult:self.touchPtPage];
 
-        CGFloat xPos = 10;
-        CGFloat yPos = 10;
+        CGFloat xPos = [self.touchPtPage getX] - (stampWidth / 2);
+        CGFloat yPos = [self.touchPtPage getY] - (stampHeight / 2);
 
         double pageWidth = [[page GetCropBox] Width];
         if (xPos > pageWidth - stampWidth)

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3835,7 +3835,7 @@
     self.touchPtPage = [self.pdfViewCtrl ConvScreenPtToPagePt:[[PTPDFPoint alloc] initWithPx:self.endPoint.x py:self.endPoint.y] page_num:_pageNumber];
 
     UIImage *rawImage = [UIImage imageNamed:@"bauhubPlusIconTool"];
-
+    
     if (rawImage) {
         self.image = [self correctForRotation:rawImage];
         [self createImageStamp];

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3724,7 +3724,6 @@
         PTImage* stampImage = [PTImage CreateWithDataSimple:[doc GetSDFDoc] buf:data buf_size:data.length encoder_hints:encoderHints];
 
         // Rotate stamp based on the pdfViewCtrl's rotation
-
         PTRotate stampRotation = (4 - ctrlRotation) % 4; // 0 = 0, 90 = 1; 180 = 2, and 270 = 3
         if ([page GetPageWidth:(e_ptcrop)] == [[page GetCropBox] Height] && [page GetPageHeight:(e_ptcrop)] == [[page GetCropBox] Width]) {
             stampRotation = (4 - ctrlRotation - 1) % 4;

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3644,7 +3644,7 @@
         hasWriteLock = YES;
 
         PTPDFDoc *doc = [self.pdfViewCtrl GetDoc];
-        
+
         PTPage* page = [doc GetPage:self.pageNumber];
         PTPDFRect* stampRect = [[PTPDFRect alloc] initWithX1:0 y1:0 x2:self.image.size.width y2:self.image.size.height];
         double maxWidth = 50.0;
@@ -3654,22 +3654,20 @@
         PTRotate pageRotation = [page GetRotation];
         PTRotate viewRotation = ((pageRotation + ctrlRotation) % 4);
 
-        PTPDFRect* pageCropBox = [page GetCropBox];
-
-        if ([pageCropBox Width] < maxWidth)
+        if ([page GetPageWidth:(e_ptcrop)] < maxWidth)
         {
-            maxWidth = [pageCropBox Width];
+            maxWidth = [page GetPageWidth:(e_ptcrop)];
         }
-        if ([pageCropBox Height] < maxHeight)
+        if ([page GetPageHeight:(e_ptcrop)] < maxHeight)
         {
-            maxHeight = [pageCropBox Height];
+            maxHeight = [page GetPageHeight:(e_ptcrop)];
         }
 
         if (viewRotation == e_pt90 || viewRotation == e_pt270) {
             // Swap width and height if visible page is rotated 90 or 270 degrees
-            //maxWidth = maxWidth + maxHeight;
-            //maxHeight = maxWidth - maxHeight;
-            //maxWidth = maxWidth - maxHeight;
+            maxWidth = maxWidth + maxHeight;
+            maxHeight = maxWidth - maxHeight;
+            maxWidth = maxWidth - maxHeight;
         }
 
         CGFloat scaleFactor = MIN(maxWidth / [stampRect Width], maxHeight / [stampRect Height]);
@@ -3678,9 +3676,9 @@
 
         if (ctrlRotation == e_pt90 || ctrlRotation == e_pt270) {
             // Swap width and height if pdfViewCtrl is rotated 90 or 270 degrees
-            //stampWidth = stampWidth + stampHeight;
-            //stampHeight = stampWidth - stampHeight;
-            //stampWidth = stampWidth - stampHeight;
+            stampWidth = stampWidth + stampHeight;
+            stampHeight = stampWidth - stampHeight;
+            stampWidth = stampWidth - stampHeight;
         }
 
         PTStamper* stamper = [[PTStamper alloc] initWithSize_type:e_ptabsolute_size a:stampWidth b:stampHeight];
@@ -3694,9 +3692,7 @@
         CGFloat xPos = [self.touchPtPage getX] - (stampWidth / 2);
         CGFloat yPos = [self.touchPtPage getY] - (stampHeight / 2);
 
-        NSLog(@"Kristjan siin: %@, %@, %@, %@, %@, %@, %@", ctrlRotation, pageRotation, viewRotation, [[page GetCropBox] Width], [[page GetCropBox] Height], xPos, yPos);
-
-        double pageWidth = [[page GetCropBox] Width];
+        double pageWidth = [page GetPageWidth:(e_ptcrop)];
         if (xPos > pageWidth - stampWidth)
         {
             xPos = pageWidth - stampWidth;
@@ -3705,7 +3701,7 @@
         {
             xPos = 0;
         }
-        double pageHeight = [[page GetCropBox] Height];
+        double pageHeight = [page GetPageHeight:(e_ptcrop)];
         if (yPos > pageHeight - stampHeight)
         {
             yPos = pageHeight - stampHeight;
@@ -3729,7 +3725,11 @@
 
         // Rotate stamp based on the pdfViewCtrl's rotation
 
-        PTRotate stampRotation = (4 - ctrlRotation) % 4; // 0 = 0, 90 = 1; 180 = 2, and 270 = 3 ,, (4 - ctrlRotation) % 4
+        PTRotate stampRotation = (4 - ctrlRotation) % 4; // 0 = 0, 90 = 1; 180 = 2, and 270 = 3
+        if ([page GetPageWidth:(e_ptcrop)] == [[page GetCropBox] Height] && [page GetPageHeight:(e_ptcrop)] == [[page GetCropBox] Width]) {
+            stampRotation = (4 - ctrlRotation - 1) % 4;
+        }
+
         [stamper SetRotation:stampRotation * 90.0];
         [stamper StampImage:doc src_img:stampImage dest_pages:pageSet];
 
@@ -3836,12 +3836,12 @@
     self.touchPtPage = [self.pdfViewCtrl ConvScreenPtToPagePt:[[PTPDFPoint alloc] initWithPx:self.endPoint.x py:self.endPoint.y] page_num:_pageNumber];
 
     UIImage *rawImage = [UIImage imageNamed:@"bauhubPlusIconTool"];
-    
+
     if (rawImage) {
         self.image = [self correctForRotation:rawImage];
         [self createImageStamp];
     }
-    
+
     // Tap handled.
     return YES;
 }
@@ -3855,7 +3855,7 @@
         hasWriteLock = YES;
 
         PTPDFDoc *doc = [self.pdfViewCtrl GetDoc];
-        
+
         PTPage* page = [doc GetPage:self.pageNumber];
         PTPDFRect* stampRect = [[PTPDFRect alloc] initWithX1:0 y1:0 x2:self.image.size.width y2:self.image.size.height];
         double maxWidth = 25.0;
@@ -3865,15 +3865,13 @@
         PTRotate pageRotation = [page GetRotation];
         PTRotate viewRotation = ((pageRotation + ctrlRotation) % 4);
 
-        PTPDFRect* pageCropBox = [page GetCropBox];
-
-        if ([pageCropBox Width] < maxWidth)
+        if ([page GetPageWidth:(e_ptcrop)] < maxWidth)
         {
-            maxWidth = [pageCropBox Width];
+            maxWidth = [page GetPageWidth:(e_ptcrop)];
         }
-        if ([pageCropBox Height] < maxHeight)
+        if ([page GetPageHeight:(e_ptcrop)] < maxHeight)
         {
-            maxHeight = [pageCropBox Height];
+            maxHeight = [page GetPageHeight:(e_ptcrop)];
         }
 
         if (viewRotation == e_pt90 || viewRotation == e_pt270) {
@@ -3905,7 +3903,7 @@
         CGFloat xPos = [self.touchPtPage getX] - (stampWidth / 2);
         CGFloat yPos = [self.touchPtPage getY] - (stampHeight / 2);
 
-        double pageWidth = [[page GetCropBox] Width];
+        double pageWidth = [page GetPageWidth:(e_ptcrop)];
         if (xPos > pageWidth - stampWidth)
         {
             xPos = pageWidth - stampWidth;
@@ -3914,7 +3912,7 @@
         {
             xPos = 0;
         }
-        double pageHeight = [[page GetCropBox] Height];
+        double pageHeight = [page GetPageHeight:(e_ptcrop)];
         if (yPos > pageHeight - stampHeight)
         {
             yPos = pageHeight - stampHeight;

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3840,7 +3840,7 @@
         self.image = [self correctForRotation:rawImage];
         [self createImageStamp];
     }
-
+    
     // Tap handled.
     return YES;
 }

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3726,7 +3726,7 @@
         PTImage* stampImage = [PTImage CreateWithDataSimple:[doc GetSDFDoc] buf:data buf_size:data.length encoder_hints:encoderHints];
 
         // Rotate stamp based on the pdfViewCtrl's rotation
-        PTRotate stampRotation = 0; // 0 = 0, 90 = 1; 180 = 2, and 270 = 3
+        PTRotate stampRotation = 1; // 0 = 0, 90 = 1; 180 = 2, and 270 = 3
         [stamper SetRotation:stampRotation * 90.0];
         [stamper StampImage:doc src_img:stampImage dest_pages:pageSet];
 

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3644,7 +3644,7 @@
         hasWriteLock = YES;
 
         PTPDFDoc *doc = [self.pdfViewCtrl GetDoc];
-
+        
         PTPage* page = [doc GetPage:self.pageNumber];
         PTPDFRect* stampRect = [[PTPDFRect alloc] initWithX1:0 y1:0 x2:self.image.size.width y2:self.image.size.height];
         double maxWidth = 50.0;

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3694,6 +3694,8 @@
         CGFloat xPos = [self.touchPtPage getX] - (stampWidth / 2);
         CGFloat yPos = [self.touchPtPage getY] - (stampHeight / 2);
 
+        NSLog(@"Kristjan siin: %@, %@, %@, %@, %@, %@, %@", ctrlRotation, pageRotation, viewRotation, [[page GetCropBox] Width], [[page GetCropBox] Height], xPos, yPos);
+
         double pageWidth = [[page GetCropBox] Width];
         if (xPos > pageWidth - stampWidth)
         {
@@ -3726,7 +3728,8 @@
         PTImage* stampImage = [PTImage CreateWithDataSimple:[doc GetSDFDoc] buf:data buf_size:data.length encoder_hints:encoderHints];
 
         // Rotate stamp based on the pdfViewCtrl's rotation
-        PTRotate stampRotation = 1; // 0 = 0, 90 = 1; 180 = 2, and 270 = 3
+
+        PTRotate stampRotation = (4 - ctrlRotation) % 4; // 0 = 0, 90 = 1; 180 = 2, and 270 = 3 ,, (4 - ctrlRotation) % 4
         [stamper SetRotation:stampRotation * 90.0];
         [stamper StampImage:doc src_img:stampImage dest_pages:pageSet];
 

--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3667,9 +3667,9 @@
 
         if (viewRotation == e_pt90 || viewRotation == e_pt270) {
             // Swap width and height if visible page is rotated 90 or 270 degrees
-            maxWidth = maxWidth + maxHeight;
-            maxHeight = maxWidth - maxHeight;
-            maxWidth = maxWidth - maxHeight;
+            //maxWidth = maxWidth + maxHeight;
+            //maxHeight = maxWidth - maxHeight;
+            //maxWidth = maxWidth - maxHeight;
         }
 
         CGFloat scaleFactor = MIN(maxWidth / [stampRect Width], maxHeight / [stampRect Height]);
@@ -3678,9 +3678,9 @@
 
         if (ctrlRotation == e_pt90 || ctrlRotation == e_pt270) {
             // Swap width and height if pdfViewCtrl is rotated 90 or 270 degrees
-            stampWidth = stampWidth + stampHeight;
-            stampHeight = stampWidth - stampHeight;
-            stampWidth = stampWidth - stampHeight;
+            //stampWidth = stampWidth + stampHeight;
+            //stampHeight = stampWidth - stampHeight;
+            //stampWidth = stampWidth - stampHeight;
         }
 
         PTStamper* stamper = [[PTStamper alloc] initWithSize_type:e_ptabsolute_size a:stampWidth b:stampHeight];
@@ -3691,8 +3691,8 @@
         PTMatrix2D *mtx = [page GetDefaultMatrix:NO box_type:e_ptcrop angle:0];
         self.touchPtPage = [mtx Mult:self.touchPtPage];
 
-        CGFloat xPos = [self.touchPtPage getX] - (stampWidth / 2);
-        CGFloat yPos = [self.touchPtPage getY] - (stampHeight / 2);
+        CGFloat xPos = 10;
+        CGFloat yPos = 10;
 
         double pageWidth = [[page GetCropBox] Width];
         if (xPos > pageWidth - stampWidth)

--- a/lib/document_view.dart
+++ b/lib/document_view.dart
@@ -14,14 +14,17 @@ class DocumentView extends StatefulWidget {
 class _DocumentViewState extends State<DocumentView> {
   @override
   Widget build(BuildContext context) {
-    final String viewType = 'pdftron_flutter/documentview';
+  final String viewType = 'pdftron_flutter/documentview';
 
     if (Platform.isAndroid) {
       return PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (BuildContext context, PlatformViewController controller) {
-            return AndroidViewSurface(controller: controller as AndroidViewController, hitTestBehavior: PlatformViewHitTestBehavior.opaque, gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>[].toSet());
-          },
+            return AndroidViewSurface(
+              controller: controller as AndroidViewController, 
+              hitTestBehavior: PlatformViewHitTestBehavior.opaque, 
+              gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>[].toSet());
+          }, 
           onCreatePlatformView: (PlatformViewCreationParams params) {
             return PlatformViewsService.initSurfaceAndroidView(
               id: params.id,
@@ -50,12 +53,14 @@ class _DocumentViewState extends State<DocumentView> {
 }
 
 class DocumentViewController {
-  DocumentViewController._(int id) : _channel = new MethodChannel('pdftron_flutter/documentview_$id');
+  DocumentViewController._(int id)
+      : _channel = new MethodChannel('pdftron_flutter/documentview_$id');
 
   final MethodChannel _channel;
 
   Future<Rect> setCustomDataForAnnotation(Annot annotation, List<String> fieldNames) async {
-    return _channel.invokeMethod(Functions.setCustomDataForAnnotation, <String, dynamic>{Parameters.annotation: jsonEncode(annotation), Parameters.fieldNames: fieldNames});
+    return _channel.invokeMethod(Functions.setCustomDataForAnnotation,
+        <String, dynamic>{Parameters.annotation: jsonEncode(annotation), Parameters.fieldNames: fieldNames});
   }
 
   Future<bool> isBauhubToolMode() async {
@@ -65,79 +70,109 @@ class DocumentViewController {
   }
 
   Future<void> openDocument(String document, {String password, Config config}) {
-    return _channel.invokeMethod(Functions.openDocument, <String, dynamic>{Parameters.document: document, Parameters.password: password, Parameters.config: jsonEncode(config)});
+    return _channel.invokeMethod(Functions.openDocument, <String, dynamic>{
+      Parameters.document: document,
+      Parameters.password: password,
+      Parameters.config: jsonEncode(config)
+    });
   }
 
   Future<void> importAnnotations(String xfdf) {
-    return _channel.invokeMethod(Functions.importAnnotations, <String, dynamic>{Parameters.xfdf: xfdf});
+    return _channel.invokeMethod(
+        Functions.importAnnotations, <String, dynamic>{Parameters.xfdf: xfdf});
   }
 
   Future<String> exportAnnotations(List<Annot> annotationList) async {
     if (annotationList == null) {
       return _channel.invokeMethod(Functions.exportAnnotations);
     } else {
-      return _channel.invokeMethod(Functions.exportAnnotations, <String, dynamic>{Parameters.annotations: jsonEncode(annotationList)});
+      return _channel.invokeMethod(
+          Functions.exportAnnotations, <String, dynamic>{
+        Parameters.annotations: jsonEncode(annotationList)
+      });
     }
   }
 
   Future<void> flattenAnnotations(bool formsOnly) {
-    return _channel.invokeMethod(Functions.flattenAnnotations, <String, dynamic>{Parameters.formsOnly: formsOnly});
+    return _channel.invokeMethod(Functions.flattenAnnotations,
+        <String, dynamic>{Parameters.formsOnly: formsOnly});
   }
 
   Future<void> deleteAnnotations(List<Annot> annotationList) {
-    return _channel.invokeMethod(Functions.deleteAnnotations, <String, dynamic>{Parameters.annotations: jsonEncode(annotationList)});
+    return _channel.invokeMethod(Functions.deleteAnnotations,
+        <String, dynamic>{Parameters.annotations: jsonEncode(annotationList)});
   }
 
   Future<void> selectAnnotation(Annot annotation) {
-    return _channel.invokeMethod(Functions.selectAnnotation, <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
+    return _channel.invokeMethod(Functions.selectAnnotation,
+        <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
   }
 
   Future<bool> hideAnnotation(Annot annotation) {
-    return _channel.invokeMethod(Functions.hideAnnotation, <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
+    return _channel.invokeMethod(Functions.hideAnnotation,
+        <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
   }
 
   Future<bool> hideAllAnnotations(int pageNumber) {
-    return _channel.invokeMethod(Functions.hideAllAnnotations, <String, dynamic>{Parameters.pageNumber: pageNumber});
+    return _channel.invokeMethod(Functions.hideAllAnnotations,
+        <String, dynamic>{Parameters.pageNumber: pageNumber});
   }
 
   Future<bool> showAnnotation(Annot annotation) {
-    return _channel.invokeMethod(Functions.showAnnotation, <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
+    return _channel.invokeMethod(Functions.showAnnotation,
+        <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
   }
 
-  Future<void> setFlagsForAnnotations(List<AnnotWithFlag> annotationWithFlagsList) {
-    return _channel.invokeMethod(Functions.setFlagsForAnnotations, <String, dynamic>{Parameters.annotationsWithFlags: jsonEncode(annotationWithFlagsList)});
+  Future<void> setFlagsForAnnotations(
+      List<AnnotWithFlag> annotationWithFlagsList) {
+    return _channel.invokeMethod(
+        Functions.setFlagsForAnnotations, <String, dynamic>{
+      Parameters.annotationsWithFlags: jsonEncode(annotationWithFlagsList)
+    });
   }
 
-  Future<void> setPropertiesForAnnotation(Annot annotation, AnnotProperty property) {
-    return _channel.invokeMethod(Functions.setPropertiesForAnnotation, <String, dynamic>{
+  Future<void> setPropertiesForAnnotation(
+      Annot annotation, AnnotProperty property) {
+    return _channel
+        .invokeMethod(Functions.setPropertiesForAnnotation, <String, dynamic>{
       Parameters.annotation: jsonEncode(annotation),
       Parameters.annotationProperties: jsonEncode(property),
     });
   }
 
-  Future<void> groupAnnotations(Annot primaryAnnotation, List<Annot> subAnnotations) {
-    return _channel.invokeMethod(Functions.groupAnnotations, <String, dynamic>{
+  Future<void> groupAnnotations(
+      Annot primaryAnnotation, List<Annot> subAnnotations) {
+    return _channel
+        .invokeMethod(Functions.groupAnnotations, <String, dynamic>{
       Parameters.annotation: jsonEncode(primaryAnnotation),
       Parameters.annotations: jsonEncode(subAnnotations),
     });
   }
 
-  Future<void> ungroupAnnotations(List<Annot> annotations) {
-    return _channel.invokeMethod(Functions.ungroupAnnotations, <String, dynamic>{
+  Future<void> ungroupAnnotations(
+      List<Annot> annotations) {
+    return _channel
+        .invokeMethod(Functions.ungroupAnnotations, <String, dynamic>{
       Parameters.annotations: jsonEncode(annotations),
     });
   }
 
   Future<void> importAnnotationCommand(String xfdfCommand) {
-    return _channel.invokeMethod(Functions.importAnnotationCommand, <String, dynamic>{Parameters.xfdfCommand: xfdfCommand});
+    return _channel.invokeMethod(Functions.importAnnotationCommand,
+        <String, dynamic>{Parameters.xfdfCommand: xfdfCommand});
   }
 
   Future<void> importBookmarkJson(String bookmarkJson) {
-    return _channel.invokeMethod(Functions.importBookmarkJson, <String, dynamic>{Parameters.bookmarkJson: bookmarkJson});
+    return _channel.invokeMethod(Functions.importBookmarkJson,
+        <String, dynamic>{Parameters.bookmarkJson: bookmarkJson});
   }
 
   Future<void> addBookmark(String title, int pageNumber) {
-    return _channel.invokeMethod(Functions.addBookmark, <String, dynamic>{Parameters.title: title, Parameters.pageNumber: pageNumber});
+    return _channel
+        .invokeMethod(Functions.addBookmark, <String, dynamic>{
+      Parameters.title: title,
+      Parameters.pageNumber: pageNumber
+    });
   }
 
   Future<String> saveDocument() {
@@ -159,7 +194,7 @@ class DocumentViewController {
   Future<void> undo() {
     return _channel.invokeMethod(Functions.undo);
   }
-
+  
   Future<void> redo() {
     return _channel.invokeMethod(Functions.redo);
   }
@@ -167,18 +202,20 @@ class DocumentViewController {
   Future<bool> canUndo() {
     return _channel.invokeMethod(Functions.canUndo);
   }
-
+  
   Future<bool> canRedo() {
     return _channel.invokeMethod(Functions.canRedo);
   }
 
   Future<Rect> getPageCropBox(int pageNumber) async {
-    String cropBoxString = await _channel.invokeMethod(Functions.getPageCropBox, <String, dynamic>{Parameters.pageNumber: pageNumber});
+    String cropBoxString = await _channel.invokeMethod(Functions.getPageCropBox,
+        <String, dynamic>{Parameters.pageNumber: pageNumber});
     return Rect.fromJson(jsonDecode(cropBoxString));
   }
 
   Future<int> getPageRotation(int pageNumber) async {
-    int pageRotation = await _channel.invokeMethod(Functions.getPageRotation, <String, dynamic>{Parameters.pageNumber: pageNumber});
+    int pageRotation = await _channel.invokeMethod(Functions.getPageRotation,
+        <String, dynamic>{Parameters.pageNumber: pageNumber});
     return pageRotation;
   }
 
@@ -191,7 +228,8 @@ class DocumentViewController {
   }
 
   Future<bool> setCurrentPage(int pageNumber) {
-    return _channel.invokeMethod(Functions.setCurrentPage, <String, dynamic>{Parameters.pageNumber: pageNumber});
+    return _channel.invokeMethod(Functions.setCurrentPage,
+        <String, dynamic>{Parameters.pageNumber: pageNumber});
   }
 
   Future<String> getDocumentPath() {
@@ -199,19 +237,27 @@ class DocumentViewController {
   }
 
   Future<void> setToolMode(String toolMode) {
-    return _channel.invokeMethod(Functions.setToolMode, <String, dynamic>{Parameters.toolMode: toolMode});
+    return _channel.invokeMethod(Functions.setToolMode,
+        <String, dynamic>{Parameters.toolMode: toolMode});
   }
 
-  Future<void> setFlagForFields(List<String> fieldNames, int flag, bool flagValue) {
-    return _channel.invokeMethod(Functions.setFlagForFields, <String, dynamic>{Parameters.fieldNames: fieldNames, Parameters.flag: flag, Parameters.flagValue: flagValue});
+  Future<void> setFlagForFields(
+      List<String> fieldNames, int flag, bool flagValue) {
+    return _channel.invokeMethod(Functions.setFlagForFields, <String, dynamic>{
+      Parameters.fieldNames: fieldNames,
+      Parameters.flag: flag,
+      Parameters.flagValue: flagValue
+    });
   }
 
   Future<void> setValuesForFields(List<Field> fields) {
-    return _channel.invokeMethod(Functions.setValuesForFields, <String, dynamic>{Parameters.fields: jsonEncode(fields)});
+    return _channel.invokeMethod(Functions.setValuesForFields,
+        <String, dynamic>{Parameters.fields: jsonEncode(fields)});
   }
 
   Future<void> setLeadingNavButtonIcon(String path) {
-    return _channel.invokeMethod(Functions.setLeadingNavButtonIcon, <String, dynamic>{Parameters.leadingNavButtonIcon: path});
+    return _channel.invokeMethod(Functions.setLeadingNavButtonIcon,
+        <String, dynamic>{Parameters.leadingNavButtonIcon: path});
   }
 
   Future<void> closeAllTabs() {
@@ -223,7 +269,11 @@ class DocumentViewController {
   }
 
   Future<String> exportAsImage(int pageNumber, int dpi, String exportFormat) {
-    return _channel.invokeMethod(Functions.exportAsImage, <String, dynamic>{Parameters.pageNumber: pageNumber, Parameters.dpi: dpi, Parameters.exportFormat: exportFormat});
+    return _channel.invokeMethod(Functions.exportAsImage, <String, dynamic>{
+      Parameters.pageNumber: pageNumber,
+      Parameters.dpi: dpi,
+      Parameters.exportFormat: exportFormat
+    });
   }
 
   Future<void> openAnnotationList() {
@@ -245,17 +295,19 @@ class DocumentViewController {
   Future<void> openThumbnailsView() {
     return _channel.invokeMethod(Functions.openThumbnailsView);
   }
-
+  
   Future<void> openRotateDialog() {
     return _channel.invokeMethod(Functions.openRotateDialog);
   }
 
   Future<void> openAddPagesView(Map<String, double> sourceRect) {
-    return _channel.invokeMethod(Functions.openAddPagesView, <String, dynamic>{Parameters.sourceRect: sourceRect});
+    return _channel.invokeMethod(Functions.openAddPagesView,
+        <String, dynamic>{Parameters.sourceRect: sourceRect});
   }
 
   Future<void> openViewSettings(Map<String, double> sourceRect) {
-    return _channel.invokeMethod(Functions.openViewSettings, <String, dynamic>{Parameters.sourceRect: sourceRect});
+    return _channel.invokeMethod(Functions.openViewSettings,
+        <String, dynamic>{Parameters.sourceRect: sourceRect});
   }
 
   Future<void> openCrop() {
@@ -273,7 +325,7 @@ class DocumentViewController {
   Future<void> openTabSwitcher() {
     return _channel.invokeMethod(Functions.openTabSwitcher);
   }
-
+  
   Future<void> openGoToPageView() {
     return _channel.invokeMethod(Functions.openGoToPageView);
   }

--- a/lib/document_view.dart
+++ b/lib/document_view.dart
@@ -15,7 +15,6 @@ class _DocumentViewState extends State<DocumentView> {
   @override
   Widget build(BuildContext context) {
     final String viewType = 'pdftron_flutter/documentview';
-    //TODO commit
 
     if (Platform.isAndroid) {
       return PlatformViewLink(

--- a/lib/document_view.dart
+++ b/lib/document_view.dart
@@ -14,17 +14,15 @@ class DocumentView extends StatefulWidget {
 class _DocumentViewState extends State<DocumentView> {
   @override
   Widget build(BuildContext context) {
-  final String viewType = 'pdftron_flutter/documentview';
+    final String viewType = 'pdftron_flutter/documentview';
+    //TODO commit
 
     if (Platform.isAndroid) {
       return PlatformViewLink(
           viewType: viewType,
           surfaceFactory: (BuildContext context, PlatformViewController controller) {
-            return AndroidViewSurface(
-              controller: controller as AndroidViewController, 
-              hitTestBehavior: PlatformViewHitTestBehavior.opaque, 
-              gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>[].toSet());
-          }, 
+            return AndroidViewSurface(controller: controller as AndroidViewController, hitTestBehavior: PlatformViewHitTestBehavior.opaque, gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>[].toSet());
+          },
           onCreatePlatformView: (PlatformViewCreationParams params) {
             return PlatformViewsService.initSurfaceAndroidView(
               id: params.id,
@@ -53,14 +51,12 @@ class _DocumentViewState extends State<DocumentView> {
 }
 
 class DocumentViewController {
-  DocumentViewController._(int id)
-      : _channel = new MethodChannel('pdftron_flutter/documentview_$id');
+  DocumentViewController._(int id) : _channel = new MethodChannel('pdftron_flutter/documentview_$id');
 
   final MethodChannel _channel;
 
   Future<Rect> setCustomDataForAnnotation(Annot annotation, List<String> fieldNames) async {
-    return _channel.invokeMethod(Functions.setCustomDataForAnnotation,
-        <String, dynamic>{Parameters.annotation: jsonEncode(annotation), Parameters.fieldNames: fieldNames});
+    return _channel.invokeMethod(Functions.setCustomDataForAnnotation, <String, dynamic>{Parameters.annotation: jsonEncode(annotation), Parameters.fieldNames: fieldNames});
   }
 
   Future<bool> isBauhubToolMode() async {
@@ -70,109 +66,79 @@ class DocumentViewController {
   }
 
   Future<void> openDocument(String document, {String password, Config config}) {
-    return _channel.invokeMethod(Functions.openDocument, <String, dynamic>{
-      Parameters.document: document,
-      Parameters.password: password,
-      Parameters.config: jsonEncode(config)
-    });
+    return _channel.invokeMethod(Functions.openDocument, <String, dynamic>{Parameters.document: document, Parameters.password: password, Parameters.config: jsonEncode(config)});
   }
 
   Future<void> importAnnotations(String xfdf) {
-    return _channel.invokeMethod(
-        Functions.importAnnotations, <String, dynamic>{Parameters.xfdf: xfdf});
+    return _channel.invokeMethod(Functions.importAnnotations, <String, dynamic>{Parameters.xfdf: xfdf});
   }
 
   Future<String> exportAnnotations(List<Annot> annotationList) async {
     if (annotationList == null) {
       return _channel.invokeMethod(Functions.exportAnnotations);
     } else {
-      return _channel.invokeMethod(
-          Functions.exportAnnotations, <String, dynamic>{
-        Parameters.annotations: jsonEncode(annotationList)
-      });
+      return _channel.invokeMethod(Functions.exportAnnotations, <String, dynamic>{Parameters.annotations: jsonEncode(annotationList)});
     }
   }
 
   Future<void> flattenAnnotations(bool formsOnly) {
-    return _channel.invokeMethod(Functions.flattenAnnotations,
-        <String, dynamic>{Parameters.formsOnly: formsOnly});
+    return _channel.invokeMethod(Functions.flattenAnnotations, <String, dynamic>{Parameters.formsOnly: formsOnly});
   }
 
   Future<void> deleteAnnotations(List<Annot> annotationList) {
-    return _channel.invokeMethod(Functions.deleteAnnotations,
-        <String, dynamic>{Parameters.annotations: jsonEncode(annotationList)});
+    return _channel.invokeMethod(Functions.deleteAnnotations, <String, dynamic>{Parameters.annotations: jsonEncode(annotationList)});
   }
 
   Future<void> selectAnnotation(Annot annotation) {
-    return _channel.invokeMethod(Functions.selectAnnotation,
-        <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
+    return _channel.invokeMethod(Functions.selectAnnotation, <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
   }
 
   Future<bool> hideAnnotation(Annot annotation) {
-    return _channel.invokeMethod(Functions.hideAnnotation,
-        <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
+    return _channel.invokeMethod(Functions.hideAnnotation, <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
   }
 
   Future<bool> hideAllAnnotations(int pageNumber) {
-    return _channel.invokeMethod(Functions.hideAllAnnotations,
-        <String, dynamic>{Parameters.pageNumber: pageNumber});
+    return _channel.invokeMethod(Functions.hideAllAnnotations, <String, dynamic>{Parameters.pageNumber: pageNumber});
   }
 
   Future<bool> showAnnotation(Annot annotation) {
-    return _channel.invokeMethod(Functions.showAnnotation,
-        <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
+    return _channel.invokeMethod(Functions.showAnnotation, <String, dynamic>{Parameters.annotation: jsonEncode(annotation)});
   }
 
-  Future<void> setFlagsForAnnotations(
-      List<AnnotWithFlag> annotationWithFlagsList) {
-    return _channel.invokeMethod(
-        Functions.setFlagsForAnnotations, <String, dynamic>{
-      Parameters.annotationsWithFlags: jsonEncode(annotationWithFlagsList)
-    });
+  Future<void> setFlagsForAnnotations(List<AnnotWithFlag> annotationWithFlagsList) {
+    return _channel.invokeMethod(Functions.setFlagsForAnnotations, <String, dynamic>{Parameters.annotationsWithFlags: jsonEncode(annotationWithFlagsList)});
   }
 
-  Future<void> setPropertiesForAnnotation(
-      Annot annotation, AnnotProperty property) {
-    return _channel
-        .invokeMethod(Functions.setPropertiesForAnnotation, <String, dynamic>{
+  Future<void> setPropertiesForAnnotation(Annot annotation, AnnotProperty property) {
+    return _channel.invokeMethod(Functions.setPropertiesForAnnotation, <String, dynamic>{
       Parameters.annotation: jsonEncode(annotation),
       Parameters.annotationProperties: jsonEncode(property),
     });
   }
 
-  Future<void> groupAnnotations(
-      Annot primaryAnnotation, List<Annot> subAnnotations) {
-    return _channel
-        .invokeMethod(Functions.groupAnnotations, <String, dynamic>{
+  Future<void> groupAnnotations(Annot primaryAnnotation, List<Annot> subAnnotations) {
+    return _channel.invokeMethod(Functions.groupAnnotations, <String, dynamic>{
       Parameters.annotation: jsonEncode(primaryAnnotation),
       Parameters.annotations: jsonEncode(subAnnotations),
     });
   }
 
-  Future<void> ungroupAnnotations(
-      List<Annot> annotations) {
-    return _channel
-        .invokeMethod(Functions.ungroupAnnotations, <String, dynamic>{
+  Future<void> ungroupAnnotations(List<Annot> annotations) {
+    return _channel.invokeMethod(Functions.ungroupAnnotations, <String, dynamic>{
       Parameters.annotations: jsonEncode(annotations),
     });
   }
 
   Future<void> importAnnotationCommand(String xfdfCommand) {
-    return _channel.invokeMethod(Functions.importAnnotationCommand,
-        <String, dynamic>{Parameters.xfdfCommand: xfdfCommand});
+    return _channel.invokeMethod(Functions.importAnnotationCommand, <String, dynamic>{Parameters.xfdfCommand: xfdfCommand});
   }
 
   Future<void> importBookmarkJson(String bookmarkJson) {
-    return _channel.invokeMethod(Functions.importBookmarkJson,
-        <String, dynamic>{Parameters.bookmarkJson: bookmarkJson});
+    return _channel.invokeMethod(Functions.importBookmarkJson, <String, dynamic>{Parameters.bookmarkJson: bookmarkJson});
   }
 
   Future<void> addBookmark(String title, int pageNumber) {
-    return _channel
-        .invokeMethod(Functions.addBookmark, <String, dynamic>{
-      Parameters.title: title,
-      Parameters.pageNumber: pageNumber
-    });
+    return _channel.invokeMethod(Functions.addBookmark, <String, dynamic>{Parameters.title: title, Parameters.pageNumber: pageNumber});
   }
 
   Future<String> saveDocument() {
@@ -194,7 +160,7 @@ class DocumentViewController {
   Future<void> undo() {
     return _channel.invokeMethod(Functions.undo);
   }
-  
+
   Future<void> redo() {
     return _channel.invokeMethod(Functions.redo);
   }
@@ -202,20 +168,18 @@ class DocumentViewController {
   Future<bool> canUndo() {
     return _channel.invokeMethod(Functions.canUndo);
   }
-  
+
   Future<bool> canRedo() {
     return _channel.invokeMethod(Functions.canRedo);
   }
 
   Future<Rect> getPageCropBox(int pageNumber) async {
-    String cropBoxString = await _channel.invokeMethod(Functions.getPageCropBox,
-        <String, dynamic>{Parameters.pageNumber: pageNumber});
+    String cropBoxString = await _channel.invokeMethod(Functions.getPageCropBox, <String, dynamic>{Parameters.pageNumber: pageNumber});
     return Rect.fromJson(jsonDecode(cropBoxString));
   }
 
   Future<int> getPageRotation(int pageNumber) async {
-    int pageRotation = await _channel.invokeMethod(Functions.getPageRotation,
-        <String, dynamic>{Parameters.pageNumber: pageNumber});
+    int pageRotation = await _channel.invokeMethod(Functions.getPageRotation, <String, dynamic>{Parameters.pageNumber: pageNumber});
     return pageRotation;
   }
 
@@ -228,8 +192,7 @@ class DocumentViewController {
   }
 
   Future<bool> setCurrentPage(int pageNumber) {
-    return _channel.invokeMethod(Functions.setCurrentPage,
-        <String, dynamic>{Parameters.pageNumber: pageNumber});
+    return _channel.invokeMethod(Functions.setCurrentPage, <String, dynamic>{Parameters.pageNumber: pageNumber});
   }
 
   Future<String> getDocumentPath() {
@@ -237,27 +200,19 @@ class DocumentViewController {
   }
 
   Future<void> setToolMode(String toolMode) {
-    return _channel.invokeMethod(Functions.setToolMode,
-        <String, dynamic>{Parameters.toolMode: toolMode});
+    return _channel.invokeMethod(Functions.setToolMode, <String, dynamic>{Parameters.toolMode: toolMode});
   }
 
-  Future<void> setFlagForFields(
-      List<String> fieldNames, int flag, bool flagValue) {
-    return _channel.invokeMethod(Functions.setFlagForFields, <String, dynamic>{
-      Parameters.fieldNames: fieldNames,
-      Parameters.flag: flag,
-      Parameters.flagValue: flagValue
-    });
+  Future<void> setFlagForFields(List<String> fieldNames, int flag, bool flagValue) {
+    return _channel.invokeMethod(Functions.setFlagForFields, <String, dynamic>{Parameters.fieldNames: fieldNames, Parameters.flag: flag, Parameters.flagValue: flagValue});
   }
 
   Future<void> setValuesForFields(List<Field> fields) {
-    return _channel.invokeMethod(Functions.setValuesForFields,
-        <String, dynamic>{Parameters.fields: jsonEncode(fields)});
+    return _channel.invokeMethod(Functions.setValuesForFields, <String, dynamic>{Parameters.fields: jsonEncode(fields)});
   }
 
   Future<void> setLeadingNavButtonIcon(String path) {
-    return _channel.invokeMethod(Functions.setLeadingNavButtonIcon,
-        <String, dynamic>{Parameters.leadingNavButtonIcon: path});
+    return _channel.invokeMethod(Functions.setLeadingNavButtonIcon, <String, dynamic>{Parameters.leadingNavButtonIcon: path});
   }
 
   Future<void> closeAllTabs() {
@@ -269,11 +224,7 @@ class DocumentViewController {
   }
 
   Future<String> exportAsImage(int pageNumber, int dpi, String exportFormat) {
-    return _channel.invokeMethod(Functions.exportAsImage, <String, dynamic>{
-      Parameters.pageNumber: pageNumber,
-      Parameters.dpi: dpi,
-      Parameters.exportFormat: exportFormat
-    });
+    return _channel.invokeMethod(Functions.exportAsImage, <String, dynamic>{Parameters.pageNumber: pageNumber, Parameters.dpi: dpi, Parameters.exportFormat: exportFormat});
   }
 
   Future<void> openAnnotationList() {
@@ -295,19 +246,17 @@ class DocumentViewController {
   Future<void> openThumbnailsView() {
     return _channel.invokeMethod(Functions.openThumbnailsView);
   }
-  
+
   Future<void> openRotateDialog() {
     return _channel.invokeMethod(Functions.openRotateDialog);
   }
 
   Future<void> openAddPagesView(Map<String, double> sourceRect) {
-    return _channel.invokeMethod(Functions.openAddPagesView,
-        <String, dynamic>{Parameters.sourceRect: sourceRect});
+    return _channel.invokeMethod(Functions.openAddPagesView, <String, dynamic>{Parameters.sourceRect: sourceRect});
   }
 
   Future<void> openViewSettings(Map<String, double> sourceRect) {
-    return _channel.invokeMethod(Functions.openViewSettings,
-        <String, dynamic>{Parameters.sourceRect: sourceRect});
+    return _channel.invokeMethod(Functions.openViewSettings, <String, dynamic>{Parameters.sourceRect: sourceRect});
   }
 
   Future<void> openCrop() {
@@ -325,7 +274,7 @@ class DocumentViewController {
   Future<void> openTabSwitcher() {
     return _channel.invokeMethod(Functions.openTabSwitcher);
   }
-  
+
   Future<void> openGoToPageView() {
     return _channel.invokeMethod(Functions.openGoToPageView);
   }


### PR DESCRIPTION
Hetkel võeti faili pikkus ja laius resolutsiooni küljest, aga mingitel juhtudel oli pdf'i resolutsioon vastupidine faili size parameetriga. Ehk kui fail oli landscapes, size 1000x500, aga reso oli mingil põhjusel 500x1000, siis annotatsioonide panemisel arvestati seda reso ning annotatsiooni ei olnud võimalik lisada faili paremasse serva. See sama asi (ma arvan) põhjustas ka selle pinni 90 kraadi pöördumise, selle ma parandasin lihtsalt if'ga ära.